### PR TITLE
resolves #103: ND2s with a single image could not be parsed properly …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.3] - 2015-10-16
+### FIXED
+- ND2s with a single image can now be parsed
+
 ## [1.1.2] - 2015-10-09
 ### ADDED
 - `Image` objects now have a `frame_number` attribute.

--- a/ftests.py
+++ b/ftests.py
@@ -1,5 +1,6 @@
 import unittest
-from functional_tests.FYLM141111001 import FunctionalTests
+from functional_tests.FYLM141111001 import FunctionalTests as FYLM141111Tests
+from functional_tests.single import FunctionalTests as SingleTests
 
 
 if __name__ == '__main__':

--- a/functional_tests/single.py
+++ b/functional_tests/single.py
@@ -1,0 +1,51 @@
+"""
+These tests require that you have a specific ND2 file created by the developer of nd2reader. You will never need to
+run them unless you're Jim Rybarski.
+
+"""
+from nd2reader import Nd2
+from datetime import datetime
+import unittest
+
+
+class FunctionalTests(unittest.TestCase):
+    def setUp(self):
+        self.nd2 = Nd2("/var/nd2s/single.nd2")
+
+    def tearDown(self):
+        self.nd2.close()
+
+    def test_shape(self):
+        self.assertEqual(self.nd2.height, 512)
+        self.assertEqual(self.nd2.width, 512)
+
+    def test_date(self):
+        self.assertEqual(self.nd2.date, datetime(2015, 10, 15, 9, 33, 5))
+
+    def test_length(self):
+        self.assertEqual(len(self.nd2), 1)
+
+    def test_frames(self):
+        self.assertEqual(len(self.nd2.frames), 1)
+
+    def test_fovs(self):
+        self.assertEqual(len(self.nd2.fields_of_view), 1)
+
+    def test_z_levels(self):
+        self.assertTupleEqual(tuple(self.nd2.z_levels), (0,))
+
+    def test_image(self):
+        image = self.nd2[0]
+        self.assertIsNotNone(image)
+
+    def test_iteration(self):
+        images = [image for image in self.nd2]
+        self.assertEqual(len(images), 1)
+
+    def test_iteration_step(self):
+        images = [image for image in self.nd2[::2]]
+        self.assertEqual(len(images), 1)
+
+    def test_iteration_backwards(self):
+        images = [image for image in self.nd2[::-1]]
+        self.assertEqual(len(images), 1)

--- a/nd2reader/parser/v3.py
+++ b/nd2reader/parser/v3.py
@@ -148,13 +148,13 @@ class V3Parser(BaseParser):
                 metadata = line
                 break
         else:
-            raise ValueError("Could not parse metadata dimensions!")
+            return six.b("")
         for line in metadata.split(six.b("\r\n")):
             if line.startswith(six.b("Dimensions:")):
                 dimension_text = line
                 break
         else:
-            raise ValueError("Could not parse metadata dimensions!")
+            return six.b("")
         return dimension_text
 
     def _parse_dimension(self, pattern, metadata_dict):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.1.2"
+VERSION = "1.1.3"
 
 setup(
     name="nd2reader",


### PR DESCRIPTION
…as they do not contain any dimension data, so when absent we can assume a single frame exists
