### PR TITLE
resolves #117. The XML-formatted strings in a few raw_metadata are no…

### DIFF
--- a/nd2reader/parser/v3.py
+++ b/nd2reader/parser/v3.py
@@ -9,6 +9,7 @@ from nd2reader.common.v3 import read_chunk, read_array, read_metadata
 import re
 import six
 import struct
+import xmltodict
 
 
 def ignore_missing(func):
@@ -83,22 +84,22 @@ class V3RawMetadata(object):
     @property
     @ignore_missing
     def lut_data(self):
-        return read_chunk(self._fh, self._label_map.lut_data)
+        return xmltodict.parse(read_chunk(self._fh, self._label_map.lut_data))
 
     @property
     @ignore_missing
     def grabber_settings(self):
-        return read_chunk(self._fh, self._label_map.grabber_settings)
+        return xmltodict.parse(read_chunk(self._fh, self._label_map.grabber_settings))
 
     @property
     @ignore_missing
     def custom_data(self):
-        return read_chunk(self._fh, self._label_map.custom_data)
+        return xmltodict.parse(read_chunk(self._fh, self._label_map.custom_data))
 
     @property
     @ignore_missing
     def app_info(self):
-        return read_chunk(self._fh, self._label_map.app_info)
+        return xmltodict.parse(read_chunk(self._fh, self._label_map.app_info))
 
     @property
     @ignore_missing

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     packages=['nd2reader', 'nd2reader.model', 'nd2reader.driver', 'nd2reader.parser', 'nd2reader.common'],
     install_requires=[
         'numpy>=1.6.2, <2.0',
-        'six>=1.4, <2.0'
+        'six>=1.4, <2.0',
+        'xmltodict>=0.9.2, <1.0'
     ],
     version=VERSION,
     description='A tool for reading ND2 files produced by NIS Elements',


### PR DESCRIPTION
…w parsed into OrderedDicts. This isn't exposed to the user but if we want to add any of the data it will be more convenient for contributors to examine the contents of the data
