### PR TITLE
#147: this mostly resolves the issue and I'm going to close it out wi…

### DIFF
--- a/nd2reader/model/image.py
+++ b/nd2reader/model/image.py
@@ -19,6 +19,12 @@ class Image(np.ndarray):
         self._channel = None
         self._z_level = None
 
+    def __array_wrap__(self, obj):
+        if len(obj.shape) == 0:
+            return obj[()]
+        else:
+            return np.ndarray.__array_wrap__(obj)
+
     def add_params(self, index, timestamp, frame_number, field_of_view, channel, z_level):
         """
         :param index: The integer that can be used to directly index this image


### PR DESCRIPTION
…th this patch, however, I'm not satisfied with the solution (taken from http://stackoverflow.com/questions/16805987/python-numpy-ndarray-subclasses-and-zero-rank-arrays). While this allows most numpy operations to work, you still can't do basic things like adding two Image objects (even though `np.sum([[n[0], n[1]]])` will work). Hopefully no one will care or notice
